### PR TITLE
added download functionality

### DIFF
--- a/bookmarklet.js
+++ b/bookmarklet.js
@@ -31,6 +31,16 @@ javascript:(
                 document.body.removeChild(dummy);
             };
 
+            const downloadFile = (text) => {
+                var dataStr = "data:text/json;charset=utf-8," + encodeURIComponent(text);                
+                var downloadAnchorNode = document.createElement('a');
+                downloadAnchorNode.setAttribute("href",     dataStr);
+                downloadAnchorNode.setAttribute("download",  "download.json");
+                document.body.appendChild(downloadAnchorNode);
+                downloadAnchorNode.click();                
+                downloadAnchorNode.remove();
+            }
+
             const onClick = () => {
                 if (!document.body.classList.contains('loading')) {
                     document.getElementById("submit-button").click();
@@ -71,7 +81,7 @@ javascript:(
                             }
 
                             /* Do nothing if there is no object */
-                            obj && copyToClipboard(JSON.stringify(obj, null, 4));
+                            obj && copyToClipboard(JSON.stringify(obj, null, 4)) && downloadFile(JSON.stringify(obj, null, 4));
                             console.logs = [];
                         }, resultWaitTime);
                     });

--- a/bookmarklet.js
+++ b/bookmarklet.js
@@ -33,17 +33,16 @@ javascript:(
             };
 
             const downloadFile = (text) => {
-            	if (document.getElementById("download-checkbox").checked === false){
-            		return;
+            	if (document.getElementById("download-checkbox").checked){
+                    let dataStr = "data:text/json;charset=utf-8," + encodeURIComponent(text);                
+                    let downloadAnchorNode = document.createElement('a');
+                    downloadAnchorNode.setAttribute("href",     dataStr);
+                    downloadAnchorNode.setAttribute("download",  "download.json");
+                    document.body.appendChild(downloadAnchorNode);
+                    downloadAnchorNode.click();                
+                    downloadAnchorNode.remove();
             	}
-                let dataStr = "data:text/json;charset=utf-8," + encodeURIComponent(text);                
-                let downloadAnchorNode = document.createElement('a');
-                downloadAnchorNode.setAttribute("href",     dataStr);
-                downloadAnchorNode.setAttribute("download",  "download.json");
-                document.body.appendChild(downloadAnchorNode);
-                downloadAnchorNode.click();                
-                downloadAnchorNode.remove();
-            }
+            };
 
             const onClick = () => {
                 if (!document.body.classList.contains('loading')) {
@@ -85,7 +84,7 @@ javascript:(
                             }
 
                             /* Do nothing if there is no object */
-                            obj && copyToClipboard(JSON.stringify(obj, null, defaultIndentation)) && downloadFile(JSON.stringify(obj, null, defaultIndentation));
+                            obj && downloadFile(JSON.stringify(obj, null, defaultIndentation)) && copyToClipboard(JSON.stringify(obj, null, defaultIndentation));
                             console.logs = [];
                         }, resultWaitTime);
                     });
@@ -94,7 +93,11 @@ javascript:(
     
             const parent = document.getElementById("submit-container");
             const button = document.createElement("a");
+            const downloadCheckboxText = document.createElement("span");
             const downloadCheckbox = document.createElement("input");
+
+
+            downloadCheckboxText.innerHTML = "Download Test File";
 
             button.innerHTML = "Copy Test File";
             button.id = "generate-button";
@@ -102,11 +105,11 @@ javascript:(
             button.href = "#!";
             button.onclick = onClick;
 
-            downloadCheckbox.innerHTML = "Download Test File";
             downloadCheckbox.type = "checkbox";
             downloadCheckbox.id = "download-checkbox";
 
             parent.appendChild(button);
+            parent.appendChild(downloadCheckboxText);
             parent.appendChild(downloadCheckbox);
         }
     }

--- a/bookmarklet.js
+++ b/bookmarklet.js
@@ -33,6 +33,9 @@ javascript:(
             };
 
             const downloadFile = (text) => {
+            	if (document.getElementById("download-checkbox").checked === false){
+            		return;
+            	}
                 let dataStr = "data:text/json;charset=utf-8," + encodeURIComponent(text);                
                 let downloadAnchorNode = document.createElement('a');
                 downloadAnchorNode.setAttribute("href",     dataStr);
@@ -91,11 +94,18 @@ javascript:(
     
             const parent = document.getElementById("submit-container");
             const button = document.createElement("a");
+            const downloadCheckbox = document.createElement("input");
+
             button.innerHTML = "Copy Test File";
             button.id = "generate-button";
             button.className = "btn";
             button.href = "#!";
             button.onclick = onClick;
+
+            downloadCheckbox.innerHTML = "Download Test File";
+            downloadCheckbox.type = "checkbox";
+            downloadCheckbox.id = "download-checkbox";
+
             parent.appendChild(button);
         }
     }

--- a/bookmarklet.js
+++ b/bookmarklet.js
@@ -107,6 +107,7 @@ javascript:(
             downloadCheckbox.id = "download-checkbox";
 
             parent.appendChild(button);
+            parent.appendChild(downloadCheckbox);
         }
     }
 )();

--- a/bookmarklet.js
+++ b/bookmarklet.js
@@ -32,6 +32,7 @@ javascript:(
                 document.body.removeChild(dummy);
             };
 
+            /* https://stackoverflow.com/questions/19721439/download-json-object-as-a-file-from-browser */
             const downloadFile = (text) => {
             	if (document.getElementById("download-checkbox").checked){
                     const dataStr = "data:text/json;charset=utf-8," + encodeURIComponent(text);                

--- a/bookmarklet.js
+++ b/bookmarklet.js
@@ -2,6 +2,7 @@ javascript:(
     function() {
         const pollInterval = 69;
         const resultWaitTime = 420;
+        const defaultIndentation = 4;
         if (!document.getElementById("generate-button")) {
             console.stdlog = console.log.bind(console);
             console.logs = [];
@@ -81,7 +82,7 @@ javascript:(
                             }
 
                             /* Do nothing if there is no object */
-                            obj && copyToClipboard(JSON.stringify(obj, null, 4)) && downloadFile(JSON.stringify(obj, null, 4));
+                            obj && copyToClipboard(JSON.stringify(obj, null, defaultIndentation)) && downloadFile(JSON.stringify(obj, null, defaultIndentation));
                             console.logs = [];
                         }, resultWaitTime);
                     });

--- a/bookmarklet.js
+++ b/bookmarklet.js
@@ -32,8 +32,8 @@ javascript:(
             };
 
             const downloadFile = (text) => {
-                var dataStr = "data:text/json;charset=utf-8," + encodeURIComponent(text);                
-                var downloadAnchorNode = document.createElement('a');
+                let dataStr = "data:text/json;charset=utf-8," + encodeURIComponent(text);                
+                let downloadAnchorNode = document.createElement('a');
                 downloadAnchorNode.setAttribute("href",     dataStr);
                 downloadAnchorNode.setAttribute("download",  "download.json");
                 document.body.appendChild(downloadAnchorNode);

--- a/bookmarklet.js
+++ b/bookmarklet.js
@@ -84,7 +84,8 @@ javascript:(
                             }
 
                             /* Do nothing if there is no object */
-                            obj && downloadFile(JSON.stringify(obj, null, defaultIndentation)) && copyToClipboard(JSON.stringify(obj, null, defaultIndentation));
+                            const stringifiedObj = JSON.stringify(obj, null, defaultIndentation);
+                            obj && downloadFile(stringifiedObj) && copyToClipboard(stringifiedObj);
                             console.logs = [];
                         }, resultWaitTime);
                     });

--- a/bookmarklet.js
+++ b/bookmarklet.js
@@ -34,10 +34,10 @@ javascript:(
 
             const downloadFile = (text) => {
             	if (document.getElementById("download-checkbox").checked){
-                    let dataStr = "data:text/json;charset=utf-8," + encodeURIComponent(text);                
-                    let downloadAnchorNode = document.createElement('a');
-                    downloadAnchorNode.setAttribute("href",     dataStr);
-                    downloadAnchorNode.setAttribute("download",  "download.json");
+                    const dataStr = "data:text/json;charset=utf-8," + encodeURIComponent(text);                
+                    const downloadAnchorNode = document.createElement('a');
+                    downloadAnchorNode.setAttribute("href", dataStr);
+                    downloadAnchorNode.setAttribute("download", "download.json");
                     document.body.appendChild(downloadAnchorNode);
                     downloadAnchorNode.click();                
                     downloadAnchorNode.remove();


### PR DESCRIPTION
previously the bookmarklet only manipulates the clipboard, which may not always work on browsers like Firefox, as Firefox have a stricter ruleset for allowing clipboard access.

This is remedied by downloading the JSON text as a JSON file directly instead. This should work on most browsers and is tested on Firefox, and further achieves time save since the user now only has to rename the file.

#SpeedrunTactics